### PR TITLE
Enable titles for colorkey

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,9 @@ Changes in lattice 0.20
    default breakpoints in histogram(). See ?histogram for details.
 
  o New datasets USMortality and USRegionalMortality.
+ 
+ o 'title' and 'cex.title' added as parameters in 'colorkey', allowing 
+   labeling of the colorkey.
 
 Changes in lattice 0.19
 =======================

--- a/R/settings.R
+++ b/R/settings.R
@@ -63,7 +63,7 @@ lower.saturation <-
 
 
 
-standard.theme <- 
+standard.theme <-
 canonical.theme <- function(name = .Device, color = name != "postscript")
 {
     ## For the purpose of this function, the only differences in the
@@ -173,7 +173,8 @@ canonical.theme <- function(name = .Device, color = name != "postscript")
                                      key.bottom = 1,
                                      key.sub.padding = 1,
                                      sub = 1,
-                                     bottom.padding = 1),
+                                     bottom.padding = 1,
+                                     colorkey.title.padding = 1),
              layout.widths    = list(left.padding = 1,
                                      key.left = 1,
                                      key.ylab.padding = 0,
@@ -188,7 +189,8 @@ canonical.theme <- function(name = .Device, color = name != "postscript")
                                      axis.key.padding = 1,
                                      ylab.right = 1,
                                      key.right = 1,
-                                     right.padding = 1),
+                                     right.padding = 1,
+                                     colorkey.title.padding = 1),
 
              box.3d           = list(alpha = 1, col = can.col[1], lty = 1, lwd = 1),
              par.xlab.text    = list(alpha = 1, cex = 1, col = can.col[1], font = 1, lineheight = 1),
@@ -484,7 +486,7 @@ show.settings <- function(x = NULL)
                    lty = par.box$lty,
                    lwd = par.box$lwd)
     }
-    
+
     xyplot(d ~ d | d,
            prepanel = function(x, y) {
                list(ylim = c(0, 1),
@@ -1157,7 +1159,8 @@ lattice.options <- function(...)
               key.bottom = list(x = 0, units = "grobheight", data = textGrob(label="")),
               key.sub.padding = list(x = 0.01, units = "snpc", data = NULL),
               sub = list(x = 0, units = "grobheight", data = textGrob(label="")),
-              bottom.padding = list(x = 0.01, units = "snpc", data = NULL)),
+              bottom.padding = list(x = 0.01, units = "snpc", data = NULL),
+              colorkey.title.padding = list(x = 0.4, units = "lines", data = NULL)),
 
          layout.widths =
          list(left.padding = list(x = 0.01, units = "snpc", data = NULL),
@@ -1174,7 +1177,8 @@ lattice.options <- function(...)
               axis.key.padding = list(x = 0.01, units = "snpc", data = NULL),
               ylab.right = list(x = 0, units = "grobwidth", data = textGrob(label="")),
               key.right = list(x = 0, units = "grobwidth", data = textGrob(label="")),
-              right.padding = list(x = 0.01, units = "snpc", data = NULL)),
+              right.padding = list(x = 0.01, units = "snpc", data = NULL),
+              colorkey.title.padding = list(x = 0.4, units = "lines", data = NULL)),
 
          highlight.gpar = list(col = "red", lwd = 2, fill = "transparent")
 

--- a/man/levelplot.Rd
+++ b/man/levelplot.Rd
@@ -215,6 +215,14 @@ contourplot(x, data, \dots)
       \item{\code{axis.text}:}{ A list giving graphical parameters for
 	the tick mark labels on the color key.  Defaults to
 	\code{trellis.par.get("axis.text")}.  }
+	
+	    
+      \item{\code{title}:}{ A character vector providing a title for
+  the colorkey.  Defaults to \code{NULL}, which means no title
+  is drawn.  }
+  
+       \item{\code{cex.title}:}{ A numeric setting the size multiplier for
+  the title of the colorkey (if it is drawn).  }
 
     }
   }


### PR DESCRIPTION
This pull request adds the ability to set a title for colorkeys using a new argument `title` and `cex.title`, like so:

```r
library(lattice)

p <- vector("list", length = 4)
space <- c("left", "right", "top", "bottom")

for (i in 1:4) {
  p[[i]] <- levelplot(1 ~ 1*1, 
                      colorkey = list(space = space[i], title = "Title"))
}

gridExtra:::grid.arrange(p[[1]], p[[2]], p[[3]], p[[4]])
```

![image](https://user-images.githubusercontent.com/13087841/57197799-f2f77c00-6f6b-11e9-9e1a-bebd8e6ddc48.png)

The motivation for this is that a user otherwise have to explain in a separate legend or in accompanying text what the colors in the colorkey refer to, and seems to be in popular demand judging by the following links:

* <https://stackoverflow.com/questions/37599716/how-to-add-a-title-to-the-color-key-on-a-contourplot>
* <http://r.789695.n4.nabble.com/Titles-on-lattice-colorkey-td907761.html>
* <https://grokbase.com/t/r/r-help/11benqtf32/r-adding-units-to-levelplots-colorkey>
* <https://stackoverflow.com/questions/36874897/r-how-to-add-legend-title-to-levelplot-saved-to-a-variable>

In order to not break old code, the default is still to not have any title. 

This functionality is still pretty basic and it would probably be a good idea to allow expressions and so forth (as with the regular xlab, ylab and zlab arguments).

Padding for the title uses a new option in `trellis.par.set()` and `lattice.options()` so that it can be controlled by the user.

I also added a line to the NEWS file and manual (in levelplot.rd).

Unfortunately, I managed to save the file with *stip trailing horizontal space* on, so a lot of the additions below are just that. Sorry for the inconvenience.
