### PR TITLE
Add filled.contour type of regions for panel.levelplot

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,13 @@ Changes in lattice 0.20
    default breakpoints in histogram(). See ?histogram for details.
 
  o New datasets USMortality and USRegionalMortality.
+ 
+ o panel.levelplot() gains a new argument 'region.type', which now,
+   in addition to the default setting "grid", allows the user to specify
+   "filled.contour", which then provides a levelplot grid similar to
+   graphics::filled.contour(). The underlying code for this is a modified
+   version of code from Paul Murrell's gridGraphics package.
+   
 
 Changes in lattice 0.19
 =======================

--- a/NEWS
+++ b/NEWS
@@ -39,7 +39,8 @@ Changes in lattice 0.20
    in addition to the default setting "grid", allows the user to specify
    "filled.contour", which then provides a levelplot grid similar to
    graphics::filled.contour(). The underlying code for this is a modified
-   version of code from Paul Murrell's gridGraphics package.
+   version of code authored by Zhijian (Jason) Wen and taken from
+   Paul Murrell's gridGraphics package.
    
 
 Changes in lattice 0.19

--- a/R/imports.R
+++ b/R/imports.R
@@ -1,0 +1,179 @@
+# The following functions are modified versions of functions from
+# the R package gridGraphics by Paul Murrell, licensed under GPL-3.
+
+## vectorization version  (main in used)
+FindPolygonVertices = function(low,  high,
+                               x1,  x2,  y1,  y2,
+                               z11,  z21,  z12,  z22,
+                               colrep){
+  
+  v1 = FindCutPoints(low, high, x1, y1, x2, y1, z11, z21)
+  v2 = FindCutPoints(low, high, y1, x2, y2, x2, z21, z22)
+  v3 = FindCutPoints(low, high, x2, y2, x1, y2, z22, z12)
+  v4 = FindCutPoints(low, high, y2, x1, y1, x1, z12, z11)
+  
+  vx = cbind(v1[[1]], v2[[2]], v3[[1]], v4[[2]])
+  vy = cbind(v1[[2]], v2[[1]], v3[[2]], v4[[1]])
+  
+  ##  track the coordinate for x and y( if non-NA's)
+  index = rowSums(!is.na(vx) )
+  ## keep if non-NAs row >= 2 (npt >= 2)
+  vx = t(vx)
+  vy = t(vy)
+  xcoor.na = as.vector(vx[, index > 2])
+  ycoor.na = as.vector(vy[, index > 2])
+  ## delete all NA's,
+  xcoor = xcoor.na[!is.na(xcoor.na)]
+  ycoor = ycoor.na[!is.na(ycoor.na)]
+  
+  id.length = index[index > 2]
+  cols = colrep[index > 2]
+  
+  out = list(x = xcoor, y = ycoor, id.length = id.length, cols = cols)
+  out
+}
+
+FindCutPoints = function(low, high, x1, y1, x2, y2, z1, z2)
+{
+  ## inner condiction begin
+  ## first ocndiction
+  c = (z1 - high) / (z1 - z2)
+  cond1 = z1 < high
+  cond2 = z1 == Inf
+  cond3 = z2 > high | z1 < low
+  
+  x.1 = ifelse(cond1, x1, 
+               ifelse(cond2, x2, x1 + c * (x2 - x1)))
+  x.1 = ifelse(cond3, NA, x.1)
+  
+  y.1 = ifelse(cond1, y1, 
+               ifelse(cond2, y1, y1))
+  y.1 = ifelse(cond3, NA, y.1)
+  
+  cond4 = z2 == -Inf
+  cond5 = z2 <= low
+  cond6 = z2 > high | z1 < low
+  
+  c = (z2 -low) / (z2 - z1)
+  x.2 = ifelse(cond4, x1,
+               ifelse(cond5, x2 - c * (x2 - x1), NA))
+  x.2 = ifelse(cond6, NA, x.2)
+  
+  y.2 = ifelse(cond4, y1,
+               ifelse(cond5, y1, NA))
+  y.2 = ifelse(cond6, NA, y.2)
+  
+  ## second condiction
+  cond7 = z1 > low
+  cond8 = z1 == -Inf
+  cond9 = z2 < low | z1 > high
+  
+  c = (z1 - low) / (z1 - z2)
+  x_1 = ifelse(cond7, x1, 
+               ifelse(cond8, x2, x1 + c * (x2 - x1)))
+  x_1 = ifelse(cond9, NA, x_1)
+  
+  y_1 = ifelse(cond7, y1, 
+               ifelse(cond8, y1, y1))
+  y_1 = ifelse(cond9, NA, y_1)
+  
+  cond10 = z2 < high
+  cond11 = z2 == Inf
+  cond12 = z2 < low | z1 > high
+  
+  c = (z2 - high) / (z2 - z1)
+  x_2 = ifelse(cond10, NA, 
+               ifelse(cond11, x1, x2 - c * (x2 - x1)))
+  x_2 = ifelse(cond12, NA, x_2)
+  
+  y_2 = ifelse(cond10, NA, 
+               ifelse(cond11, y1, y1))
+  y_2 = ifelse(cond12, NA, y_2)
+  
+  ## third condiction
+  cond13 = low <= z1 & z1 <= high
+  x..1 = ifelse(cond13, x1, NA)
+  y..1 = ifelse(cond13, y1, NA)
+  ## inner condiction end
+  
+  ## outer condiction 
+  cond14 = z1 > z2
+  cond15 = z1 < z2
+  
+  xout.1 = ifelse(cond14, x.1,
+                  ifelse(cond15, x_1,
+                         x..1))
+  xout.2 = ifelse(cond14, x.2,
+                  ifelse(cond15, x_2,
+                         NA))						
+  
+  yout.1 = ifelse(cond14, y.1,
+                  ifelse(cond15, y_1,
+                         y..1))
+  yout.2 = ifelse(cond14, y.2,
+                  ifelse(cond15, y_2,
+                         NA))			
+  ## outer condiction end
+  
+  ## return x1, x2, y1, y2
+  xout = cbind(xout.1, xout.2)
+  yout = cbind(yout.1, yout.2)
+  list(xout, yout)
+}
+
+filledContour = function(x, y, z, s, cols, name, border, lwd, lty, alpha)
+{
+  ns = length(s)
+  nx = length(x)
+  ny = length(y)
+  
+  x1 = rep(x[-nx], each = ny - 1)
+  x2 = rep(x[-1], each = ny - 1)
+  y1 = rep(y[-ny], nx - 1)
+  y2 = rep(y[-1], nx - 1)
+  
+  z11 = as.numeric(t(z[-nx, -ny]))
+  z21 = as.numeric(t(z[-1, -ny ]))
+  z12 = as.numeric(t(z[-nx, -1]))
+  z22 = as.numeric(t(z[-1, -1]))
+  
+  x1 = rep(x1, each = ns - 1)
+  x2 = rep(x2, each = ns - 1)
+  y1 = rep(y1, each = ns - 1)
+  y2 = rep(y2, each = ns - 1)
+  z11 = rep(z11, each = ns - 1)
+  z12 = rep(z12, each = ns - 1)
+  z21 = rep(z21, each = ns - 1)
+  z22 = rep(z22, each = ns - 1)
+  low = rep(s[-ns], (nx - 1) * (ny - 1))
+  high = rep(s[-1], (nx - 1) * (ny - 1))
+  
+  ## rep color until the same length of x, then subsetting 
+  if (length(cols) > ns) {
+    cols = cols[1:(ns - 1)]
+  } else {
+    cols = rep_len(cols, ns - 1)
+  }
+  
+  colrep = rep(cols[1:(ns - 1)], nx * ny)
+  
+  ## feed color as well as subseeting as x and y
+  out = FindPolygonVertices(
+    low = low, high = high,
+    x1 = x1, x2 = x2, 
+    y1 = y1, y2 = y2,
+    z11 = z11, z21 = z21, 
+    z12 = z12, z22 = z22, colrep = colrep)
+  ## actual drawing
+  
+  grid.polygon(out$x, out$y, default.units = 'native',
+               id.lengths = out$id.length,
+               gp = gpar(fill = out$cols, 
+                         col = border,
+                         lwd = lwd,
+                         lty = lty,
+                         alpha = alpha),
+               name = name)
+}
+
+

--- a/R/levelplot.R
+++ b/R/levelplot.R
@@ -122,12 +122,14 @@ panel.levelplot <-
              border.lty = 1,
              border.lwd = 0.1,
              ...,
+             region.type = c("grid", "filled.contour"),
              col.regions = regions$col,
              alpha.regions = regions$alpha,
              identifier = "levelplot")
 {
     if (length(subscripts) == 0) return()
     regions <- trellis.par.get("regions")
+    region.type <- match.arg(region.type)
     label.style <- match.arg(label.style)
     x.is.factor <- is.factor(x)
     y.is.factor <- is.factor(y)
@@ -238,20 +240,48 @@ panel.levelplot <-
     idx <- match(x, ux)
     idy <- match(y, uy)
 
-    if (region) 
-        grid.rect(x = cx[idx],
-                  y = cy[idy],
-                  width = lx[idx] * scaleWidth(z, shrinkx[1], shrinkx[2], fullZrange),
-                  height = ly[idy] * scaleWidth(z, shrinky[1], shrinky[2], fullZrange),
-                  default.units = "native",
-                  name = trellis.grobname(paste(identifier, "rect", sep="."),
-                    type = "panel", group = group),
-                  gp =
-                  gpar(fill = zcol,
-                       col = border,
-                       lwd = border.lwd,
-                       lty = border.lty,
-                       alpha = alpha.regions))
+    if (region)
+    {
+        if (region.type == "grid")
+        {
+            grid.rect(x = cx[idx],
+                      y = cy[idy],
+                      width = lx[idx] * scaleWidth(z, shrinkx[1], shrinkx[2], fullZrange),
+                      height = ly[idy] * scaleWidth(z, shrinky[1], shrinky[2], fullZrange),
+                      default.units = "native",
+                      name = trellis.grobname(paste(identifier, "rect", sep="."),
+                                              type = "panel", group = group),
+                      gp =
+                          gpar(fill = zcol,
+                               col = border,
+                               lwd = border.lwd,
+                               lty = border.lty,
+                               alpha = alpha.regions))
+        }
+        else if (region.type == "filled.contour")
+        {
+            numcol <- length(at) - 1
+            cols <- level.colors(x = seq_len(numcol) - 0.5,
+                                 at = seq_len(numcol + 1) - 1,
+                                 col.regions = col.regions,
+                                 colors = TRUE)
+            
+            filledContour(x = cx,
+                          y = cy,
+                          z = matrix(z, length(cx)), 
+                          s = at, 
+                          cols = cols,
+                          name = trellis.grobname(paste(identifier, 
+                                                        "polygon", 
+                                                        sep = "."),
+                                                  type = "panel", 
+                                                  group = group),
+                          border = border,
+                          lwd = border.lwd,
+                          lty = border.lty,
+                          alpha = alpha.regions)
+        }
+    } 
 
     if (contour)
     {

--- a/inst/COPYRIGHTS
+++ b/inst/COPYRIGHTS
@@ -1,4 +1,4 @@
 file R/imports.R
 
-contains modified code from the R package gridGraphics by Paul Murrell,
-which is licensed under GPL-3.
+contains modified code authored by Zhijian (Jason) Wen and Paul Murrell 
+from the R package gridGraphics, which is licensed under GPL-3.

--- a/inst/COPYRIGHTS
+++ b/inst/COPYRIGHTS
@@ -1,0 +1,4 @@
+file R/imports.R
+
+contains modified code from the R package gridGraphics by Paul Murrell,
+which is licensed under GPL-3.

--- a/man/panel.levelplot.Rd
+++ b/man/panel.levelplot.Rd
@@ -24,6 +24,7 @@ panel.levelplot(x, y, z,
                 border.lty = 1,
                 border.lwd = 0.1,
                 \dots,
+                region.type = c("grid", "filled.contour"),
                 col.regions = regions$col,
                 alpha.regions = regions$alpha,
                 identifier = "levelplot")
@@ -102,6 +103,15 @@ panel.levelplot.raster(x, y, z,
   \item{border.lty, border.lwd}{ Graphical parameters for the border}
 %   \item{cex, col.text, font, fontfamily, fontface}{ graphical parameters for contour labels}
   \item{\dots}{ Extra parameters. }
+  \item{region.type}{
+    A character string, one of \code{"grid"} and \code{"filled.contour"}. The
+    former (the default) uses a grid of rectangles to display the
+    colors for the level plot; the latter uses a grid of polygons, mimicking
+    the behavior of \code{\link{filled.contour}}, which gives a smoother
+    appearance at the cost of increased processing time. The functionality
+    of \code{"filled.contour"} is enabled by borrowed code from Paul Murrel's
+    gridGraphics package.
+  }
   \item{col.regions}{
     A vector of colors, or a function to produce a vecor of colors, to
     be used if \code{region=TRUE}.  Each interval defined by \code{at}
@@ -154,10 +164,13 @@ levelplot(volcano, panel = panel.levelplot.raster,
           col.regions = topo.colors, cuts = 30, interpolate = TRUE)
 
 }
-\author{ Deepayan Sarkar \email{Deepayan.Sarkar@R-project.org}}
+\author{ Deepayan Sarkar \email{Deepayan.Sarkar@R-project.org},
+         Paul Murrell (\code{region.type = "filled.contour"} uses code from
+                       Paul Murrell's gridGraphics package.)}
 \seealso{
   \code{\link{levelplot}},
   \code{\link{level.colors}},
-  \code{\link{contourLines}}
+  \code{\link{contourLines}},
+  \code{\link{filled.contour}}
 }
 \keyword{dplot}

--- a/man/panel.levelplot.Rd
+++ b/man/panel.levelplot.Rd
@@ -165,8 +165,9 @@ levelplot(volcano, panel = panel.levelplot.raster,
 
 }
 \author{ Deepayan Sarkar \email{Deepayan.Sarkar@R-project.org},
-         Paul Murrell (\code{region.type = "filled.contour"} uses code from
-                       Paul Murrell's gridGraphics package.)}
+         Zhijian (Jason) Wen (authored the code used
+         when \code{region.type = "filled.contour"}, which is borrowed from
+         Paul Murrell's gridGraphics package.)}
 \seealso{
   \code{\link{levelplot}},
   \code{\link{level.colors}},


### PR DESCRIPTION
This pull request adds a new type of plotting for regions using code from gridGraphics by Paul Murrell to mimick the behavior of `filled.contour()`. The idea here is basically that the current design of levelplots doesn't work very well when `contour = TRUE` since the jagged rectangles don't match up with the contours.

I borrowed code from gridGraphics to then provide an alternative way of plotting levelplots, which is activated using a new argument `region.type = "filled.contour"`. The following figures showcase the results:

```r
require(stats)
attach(environmental)
ozo.m <- loess((ozone^(1/3)) ~ wind * temperature,
               parametric = "wind", span = 1, degree = 2)
w.marginal <- seq(min(wind), max(wind), length.out = 50)
t.marginal <- seq(min(temperature), max(temperature), length.out = 50)
wtr.marginal <- list(wind = w.marginal, temperature = t.marginal)
grid <- expand.grid(wtr.marginal)
grid[, "fit"] <- c(predict(ozo.m, grid))

contourplot(fit ~ wind * temperature, data = grid, region = TRUE)
contourplot(fit ~ wind * temperature, data = grid, region = TRUE,
            region.type = "filled.contour")
detach()
```

![image](https://user-images.githubusercontent.com/13087841/57485062-062b8400-72ab-11e9-8617-26370c845262.png)

![image](https://user-images.githubusercontent.com/13087841/57485076-0b88ce80-72ab-11e9-9276-668bbcd0599a.png)

There are a few remaining problems:

* These new filled contours take much longer time to compute. I would, however, we willing to port the code to C if this pull request is accepted.
* The new regions don't extend all the way to the boundaries.

In addition to enabling the functionality, this pull request also

* Adds a copyrights notice for Paul Murrell in a new file inst/COPYRIGHTS
* Adds a NEWS item
* Documents the new functionality in panel.levelplot.man.
