### PR TITLE
Smarter key behavior when type argument is provided

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -88,6 +88,10 @@ Changes in lattice 0.19
  o Expanded trellis.grobname() and used it to provide a name for all grobs.
 
  o New panel.spline() function.
+ 
+ o xyplot() now uses the 'type' argument (if provided) to set smarter
+   default for the key, so that it, for instance, uses lines when type = "l" and
+   points if type = "p".
 
 bug fixes
 ---------

--- a/R/update.trellis.R
+++ b/R/update.trellis.R
@@ -308,10 +308,29 @@ update.trellis <-
             groups <- object$panel.args.common$groups
             if (needAutoKey(auto.key, groups))
             {
+                type <- dots$type
+                
+                if (!is.character(type) || length(type) == 0)
+                    type <- object$panel.args.common$type
+                
+                if (is.character(type) && length(type) > 0)
+                {
+                    points <- any(type %in% c("p", "b", "o"))
+                    lines <- any(type %in% c("l", "b", "o", "h", "s", "S", "a",
+                                             "smooth", "spline", "r"))
+                }
+                else
+                {
+                    points <- TRUE
+                    lines <- FALSE
+                }
+                                
                 object$legend <-
                     list(list(fun = "drawSimpleKey",
                               args =
-                              updateList(list(text = levels(as.factor(groups))), 
+                              updateList(list(text = levels(as.factor(groups)),
+                                              points = points,
+                                              lines = lines), 
                                          if (is.list(auto.key)) auto.key else list())))
                 object$legend[[1]]$x <- object$legend[[1]]$args$x
                 object$legend[[1]]$y <- object$legend[[1]]$args$y

--- a/R/xyplot.R
+++ b/R/xyplot.R
@@ -437,13 +437,28 @@ xyplot.formula <-
 
     if (is.null(foo$legend) && needAutoKey(auto.key, groups))
     {
+        # provide smart defaults for auto key
+        type <- dots$type
+
+        if (is.character(type) && length(type) > 0)
+        {
+            points <- any(type %in% c("p", "b", "o"))
+            lines <- any(type %in% c("l", "b", "o", "h", "s", "S", "a",
+                                     "smooth", "spline", "r"))
+        }
+        else
+        {
+            points <- TRUE
+            lines <- FALSE
+        }
+        
         foo$legend <-
             list(list(fun = "drawSimpleKey",
                       args =
                       updateList(list(text = levels(as.factor(groups)),
-                                      points = TRUE,
+                                      points = points,
                                       rectangles = FALSE,
-                                      lines = FALSE), 
+                                      lines = lines), 
                                  if (is.list(auto.key)) auto.key else list())))
         foo$legend[[1]]$x <- foo$legend[[1]]$args$x
         foo$legend[[1]]$y <- foo$legend[[1]]$args$y


### PR DESCRIPTION
This pull request tries to make `xyplot()` automatically adjust legend parameters `lines` and `points` based on input to the `type` argument in `xyplot()`. The idea is simply to check if `type` has been provided and if so set the arguments in the call to `simpleKey()` based on input to `type`.

Here are some examples:

```r
library(lattice)

xyplot(mpg ~ hp, groups = cyl, data = mtcars, type = "l", auto.key = TRUE)
```
![image](https://user-images.githubusercontent.com/13087841/58123174-8e931880-7c0b-11e9-935f-1a549e834fa1.png)

```r
xyplot(mpg ~ hp, groups = cyl, data = mtcars, type = "o", auto.key = TRUE)
```

![image](https://user-images.githubusercontent.com/13087841/58123198-9b177100-7c0b-11e9-8633-a50ee2805116.png)

```r
xyplot(mpg ~ hp, groups = cyl, data = mtcars, type = c("s", "p"), auto.key = TRUE)
```

![image](https://user-images.githubusercontent.com/13087841/58123230-a66a9c80-7c0b-11e9-9367-e48770aafae4.png)

I've also made changes to `update.trellis()` to provide similar functionality. However, in case there is already a legend in the trellis object, no changes are made to the arguments for `simpleKey()`, which I think is safest.

```r
p <- xyplot(mpg ~ hp, groups = cyl, data = mtcars, type = "l")

update(p, auto.key = TRUE, type = "p")
```
![image](https://user-images.githubusercontent.com/13087841/58123313-d4e87780-7c0b-11e9-8b57-2b95a189d442.png)
