### PR TITLE
ensure that colorkey labels are in sync with 'labels$at'

### DIFF
--- a/R/legend.R
+++ b/R/legend.R
@@ -874,11 +874,17 @@ draw.colorkey <- function(key, draw = FALSE, vp = NULL)
     else if (is.list(key$lab))
     {
         at <- if (!is.null(key$lab$at)) key$lab$at else lpretty(atrange, key$tick.number)
-        at <- at[at >= atrange[1] & at <= atrange[2]]
         labels <- if (!is.null(key$lab$lab)) {
+            if (is.null(key$lab$at))
+                stop("key specifies 'labels$labels' but not 'labels$at'", call. = FALSE)
+            if (length(key$lab$lab) != length(key$lab$at))
+                stop("lengths of key's 'labels$labels' and 'labels$at' differ", call. = FALSE)
             check.overlap <- FALSE
             key$lab$lab
         } else format(at, trim = TRUE)
+        .include <- at >= atrange[1] & at <= atrange[2]
+        at     <- at    [.include]
+        labels <- labels[.include]
         if (!is.null(key$lab$cex)) cex <- key$lab$cex
         if (!is.null(key$lab$col)) col <- key$lab$col
         if (!is.null(key$lab$font)) font <- key$lab$font

--- a/tests/levelplot.R
+++ b/tests/levelplot.R
@@ -13,6 +13,12 @@ levelplot(z ~ x * y, subset(foo, z > 150), contour = T)
 levelplot(z ~ x * y, foo, subset = z > 150, contour = T)
 contourplot(z ~ x * y, foo, subset = z > 150, cuts = 10)
 
+## manual colorkey labels
+levelplot(z ~ x * y, foo, subset = z > 150,
+          colorkey = list(labels = list(at     = c(145, 150),
+                                        labels = c("below min", 150))))
+## lattice <= 0.21-5 put the "below min" label at z=150
+
 ## subset group interaction has problems (does it any longer):
 
 cloud(Sepal.Length ~ Petal.Length * Petal.Width, 


### PR DESCRIPTION
If custom labels are provided for a colorkey, lattice may put the labels at the wrong ticks. This happens when there are 'labels$at' values below the "atrange" of the color breaks. See the added example in `tests/levelplot.R`.

The patch is simple. I've also added explicit checks for `labels$labels` similar to what `axis()` does: custom `labels` cannot be specified without `at`, and they need to have the same length (not least for the patch to make sense).
