### PR TITLE
Add vector argument support to panel.violinplot

### DIFF
--- a/R/bwplot.R
+++ b/R/bwplot.R
@@ -815,13 +815,20 @@ panel.violin <-
     # Recycle arguments
     # Add index to ensure that arguments are multiple of number of groups
     darg$index <- seq_along(numeric.list)
-    darg.df <- do.call(data.frame, darg)
-    stopifnot(nrow(darg.df) == length(numeric.list))
-    darg.df$index <- NULL
+    darg <- tryCatch({
+      do.call(data.frame, darg)
+      }, error = function(e) {
+        darg$index <- NULL
+        stop(sprintf('%s must be length 1 or a vector of 
+             length multiple of group length (%d)',
+                     paste0(names(darg), collapse = ', '),
+                     length(numeric.list)))
+      })
+    darg$index <- NULL
 
     levels.fos <- as.numeric(names(numeric.list))
     d.list <- lapply(seq_along(numeric.list), function(i) {
-      my.density(numeric.list[[i]], darg.df[i, ])
+      my.density(numeric.list[[i]], darg[i, ])
       })
     ## n.list <- sapply(numeric.list, length)  UNNECESSARY
     dx.list <- lapply(d.list, "[[", "x")
@@ -841,7 +848,16 @@ panel.violin <-
     plot.arg$lwd <- lwd
 
     plot.arg$index <- seq_along(numeric.list)
-    plot.arg <- do.call(data.frame, plot.arg)
+
+    plot.arg <- tryCatch({
+      do.call(data.frame, plot.arg)
+      }, error = function(e) {
+        plot.arg$index <- NULL
+        stop(sprintf('%s must be length 1 or a vector of 
+             length multiple of group length (%d)',
+                     paste0(names(plot.arg), collapse = ', '),
+                     length(numeric.list)))
+      })
     plot.arg$index <- NULL
 
     cur.limits <- current.panel.limits()

--- a/R/bwplot.R
+++ b/R/bwplot.R
@@ -800,9 +800,10 @@ panel.violin <-
     darg$to <- to
     darg$cut <- cut
     darg$na.rm <- na.rm
-    my.density <- function(x)
+
+    my.density <- function(x, density.args)
     {
-        ans <- try(do.call(stats::density, c(list(x = x), darg)), silent = TRUE)
+        ans <- try(do.call(stats::density, c(list(x = x), density.args)), silent = TRUE)
         ## if (inherits(ans, "try-error")) list(x = numeric(0), y = numeric(0)) else ans
         if (inherits(ans, "try-error"))
             list(x = rep(x[1], 3),
@@ -810,8 +811,18 @@ panel.violin <-
         else ans
     }
     numeric.list <- if (horizontal) split(x, factor(y)) else split(y, factor(x))
+
+    # Recycle arguments
+    # Add index to ensure that arguments are multiple of number of groups
+    darg$index <- seq_along(numeric.list)
+    darg.df <- do.call(data.frame, darg)
+    stopifnot(nrow(darg.df) == length(numeric.list))
+    darg.df$index <- NULL
+
     levels.fos <- as.numeric(names(numeric.list))
-    d.list <- lapply(numeric.list, my.density)
+    d.list <- lapply(seq_along(numeric.list), function(i) {
+      my.density(numeric.list[[i]], darg.df[i, ])
+      })
     ## n.list <- sapply(numeric.list, length)  UNNECESSARY
     dx.list <- lapply(d.list, "[[", "x")
     dy.list <- lapply(d.list, "[[", "y")
@@ -820,6 +831,18 @@ panel.violin <-
     if (varwidth) max.d[] <- max(max.d)
 
     ##str(max.d)
+    # Plot arguments either 1 or multiple of number of groups
+    plot.arg <- list()
+    plot.arg$alpha <- alpha
+    # Map fill = col, col = border for gpar call
+    plot.arg$fill <- col
+    plot.arg$col <- border
+    plot.arg$lty <- lty
+    plot.arg$lwd <- lwd
+
+    plot.arg$index <- seq_along(numeric.list)
+    plot.arg <- do.call(data.frame, plot.arg)
+    plot.arg$index <- NULL
 
     cur.limits <- current.panel.limits()
     xscale <- cur.limits$xlim
@@ -846,7 +869,7 @@ panel.violin <-
                              default.units = "native",
                              name = trellis.grobname(identifier,
                                type = "panel", group = group),
-                             gp = gpar(fill = col, col = border, lty = lty, lwd = lwd, alpha = alpha))
+                             gp = do.call(gpar, plot.arg[i, ]))
                 popViewport()
             }
         }
@@ -866,7 +889,7 @@ panel.violin <-
                              default.units = "native",
                              name = trellis.grobname(identifier,
                                type = "panel", group = group),
-                             gp = gpar(fill = col, col = border, lty = lty, lwd = lwd, alpha = alpha))
+                             gp = do.call(gpar, plot.arg[i, ]))
                 popViewport()
             }
         }


### PR DESCRIPTION
Allows the user to pass vector arguments to `panel.violinplot`. Adheres to "recycling" R rules by making sure that all arguments are a multiple of the group length.
Fixes a few issues but is the first part of issue #27 

Normal behavior remains the same
``` r
library(lattice)

simple.data <- data.frame(
    values = c(rep(1, 5), rnorm(50, sd = 2), rgamma(100, shape = 0.5)),
    variable = c(rep("a", 5), rep("b", 50), rep("c", 100))
    )

# Normal behavior
bwplot(values ~ variable,
    data = simple.data,
    ylim = c(-5, 10),
    panel = function(...) {
        panel.violin(...)
    })
```

![](https://i.imgur.com/CtwNC8R.png)

``` r

# Pass vector of arguments for plot arguments (col and alpha)
bwplot(values ~ variable,
    data = simple.data,
    ylim = c(-5, 10),
    panel = function(...) {
        panel.violin(...,
                     col = c("orange", "chartreuse4", "darkorchid4"),
                     alpha = c(1, 0.5, 0.25),
                     lty = 1,
                     border = 'red')
    })
```

![](https://i.imgur.com/87LMV9l.png)

``` r

# Error behavior
bwplot(values ~ variable,
    data = simple.data,
    ylim = c(-5, 10),
    panel = function(...) {
        panel.violin(...,
                     col = c("orange", "chartreuse4", "darkorchid4"),
                     alpha = c(1, 0.5, 0.25),
                     lty = c(1, 2), # Error here
                     border = 'red')
    })
```

![](https://i.imgur.com/UgwarBK.png)

``` r

# Density specific args for each group
bwplot(values ~ variable,
    data = simple.data,
    ylim = c(-5, 10),
    panel = function(...) {
        panel.violin(...,
                     col = c("orange", "chartreuse4", "darkorchid4"),
                     alpha = c(1, 0.5, 0.25),
                     lty = c(2),
                     border = 'red',
                     cut = c(0, 3, 3))
    })
```

![](https://i.imgur.com/PrV10zv.png)

``` r

# Error when plot args are not multiple of group length
bwplot(values ~ variable,
    data = simple.data,
    ylim = c(-5, 10),
    panel = function(...) {
        panel.violin(...,
                     col = c("orange", "chartreuse4", "darkorchid4"),
                     alpha = c(1, 0.5, 0.25),
                     lty = c(2, 1),  # Error here
                     border = 'red',
                     cut = c(0, 3, 3))
    })
```

![](https://i.imgur.com/uRndFnz.png)

``` r

# Error when density args are not multiple of group length
bwplot(values ~ variable,
    data = simple.data,
    ylim = c(-5, 10),
    panel = function(...) {
        panel.violin(...,
                     col = c("orange", "chartreuse4", "darkorchid4"),
                     alpha = c(1, 0.5, 0.25),
                     lty = c(2),
                     border = 'red',
                     cut = c(0, 3, 3),
                     from = c(1, 2) # Error here
                     )
    })
```

![](https://i.imgur.com/I7pU1Nt.png)

<sup>Created on 2023-02-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>