### PR TITLE
New color defaults

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,12 +18,12 @@ Description: A powerful and elegant high-level data visualization
   multivariate data. Lattice is sufficient for typical graphics needs,
   and is also flexible enough to handle most nonstandard requirements.
   See ?Lattice for an introduction.
-Depends: R (>= 3.6.0)
-Suggests: KernSmooth, MASS, latticeExtra
+Depends: R (>= 4.0.0)
+Suggests: KernSmooth, MASS, latticeExtra, colorspace
 Imports: grid, grDevices, graphics, stats, utils
 Enhances: chron
 LazyLoad: yes
 LazyData: yes
 License: GPL (>= 2)
-URL: http://lattice.r-forge.r-project.org/
+URL: https://lattice.r-forge.r-project.org/
 BugReports: https://github.com/deepayan/lattice/issues

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -10,7 +10,8 @@ importFrom(grDevices,
            dev.hold, dev.flush, dev.capabilities,
            dev.list, cm.colors, gray, col2rgb, rgb, adjustcolor,
            heat.colors, grey, hsv, xy.coords, axisTicks,
-           boxplot.stats, contourLines, colorRampPalette, as.raster)
+           boxplot.stats, contourLines, colorRampPalette, as.raster,
+           hcl.colors, palette.colors, convertColor)
 
 importFrom(graphics, par, plot, co.intervals, hist)
 

--- a/R/settings.R
+++ b/R/settings.R
@@ -136,7 +136,7 @@ canonical.theme <- function(name, color = TRUE,
                             symbol = palette.colors(8, "Okabe-Ito")[c(6, 2, 4, 7, 3, 5, 8)],
                             fill   = NULL,
                             region = hcl.colors(12, "YlGnBu", rev = TRUE),
-                            reference = "#e8e8e8",
+                            reference = "gray90",
                             bg = "transparent",
                             fg = "black",
                             ...)

--- a/R/settings.R
+++ b/R/settings.R
@@ -23,7 +23,7 @@ col.whitebg <- function()
          plot.polygon = list(col="#c8ffc8"),
          box.rectangle = list(col="darkgreen"),
          box.umbrella = list(col="darkgreen"),
-         dot.line = list(col="#e8e8e8"),
+         dot.line = list(col="gray90"),
          dot.symbol = list(col="darkgreen"),
          plot.line = list(col="darkgreen"),
          plot.symbol = list(col="darkgreen"),
@@ -34,7 +34,7 @@ col.whitebg <- function()
                                       "#0080ff", "#ff00ff", "#ff0000", "#ffff00")),
          strip.background = list(col = c("#ffe5cc", "#ccffcc", "#ccffff",
                                          "#cce6ff", "#ffccff", "#ffcccc", "#ffffcc")),
-         reference.line = list(col="#e8e8e8"),
+         reference.line = list(col="gray90"),
          superpose.line = list(col = c("darkgreen","red","royalblue",
                                        "brown","orange","turquoise", "orchid"),
                                lty = 1:7),
@@ -85,8 +85,8 @@ lower.saturation <-
 
 custom_theme <-
     function(symbol, fill, region,
-             reference = "#e8e8e8", bg = "transparent", fg = "black",
-             strip.bg = "#f2f2f2", strip.fg = "#b2b2b2",
+             reference = "gray90", bg = "transparent", fg = "black",
+             strip.bg = "gray95", strip.fg = "gray70",
              ...)
 {
     theme <-

--- a/R/settings.R
+++ b/R/settings.R
@@ -49,12 +49,30 @@ col.whitebg <- function()
 ## saturated versions of the symbol and line colors
 
 lower.saturation <-
-    function(x, f = 0.2)
+    function(x, f = 0.2, space = c("RGB", "HCL"))
 {
+    ## lower saturation in RGB or HCL space?
+    space <- match.arg(tolower(space), c("rgb", "hcl"))
+    
+    ## for HCL space ideally colorspace::lighten() should be used
+    if((space == "hcl") && requireNamespace("colorspace")) {
+        return(colorspace::lighten(x, amount = 1 - f))
+    }
+    
+    ## for RGB space the old implementation from lattice is used,
+    ## for HCL space (if colorspace is unavailable) an approximation in LUV is used
     RGB <- col2rgb(x)
-    RGB[] <- 255 - RGB
-    RGB[] <- round(f * RGB)
-    RGB[] <- 255 - RGB
+    if(space == "rgb") {
+        RGB[] <- 255 - RGB
+        RGB[] <- round(f * RGB)
+        RGB[] <- 255 - RGB
+    } else {
+        ## adjust L coordinate of HCL/LUV only, chroma is left as it is
+        LUV <- convertColor(t(RGB), from = "sRGB", to = "Luv", scale.in = 255)
+        Lold <- pmin(100, pmax(0, LUV[, "L"]))
+        LUV[, "L"] <- 100 - (100 - Lold) * f
+        RGB[] <- t(convertColor(LUV, from = "Luv", to = "sRGB", scale.out = 255))
+    }
     rgb(RGB["red", ],
         RGB["green", ],
         RGB["blue", ],

--- a/R/settings.R
+++ b/R/settings.R
@@ -126,20 +126,22 @@ custom_theme <-
 
 
 ## (v0.21) Extended to make it easy to provide user-supplied
-## colors. Defaults to hcl palettes reordered to match classic theme,
-## and region = hcl.colors(12, "YlGnBu")). Old
-## standard.theme() / canonical.theme() renamed to classic.theme()
+## colors. Defaults to Okabe-Ito reordered to match classic theme somewhat better,
+## and region = hcl.colors(12, "YlGnBu")).
+## Fill colors are by default lightened versions of the symbol colors.
+## Old standard.theme() / canonical.theme() renamed to classic.theme()
 
 standard.theme <- 
 canonical.theme <- function(name, color = TRUE,
-                            symbol = palette.colors(8, "Okabe-Ito")[c(6, 2, 4, 8, 7, 3, 5)],
-                            fill   = palette.colors(7, "Set 2")[c(3, 6, 1, 4, 2, 5, 7)],
+                            symbol = palette.colors(8, "Okabe-Ito")[c(6, 2, 4, 7, 3, 5, 8)],
+                            fill   = NULL,
                             region = hcl.colors(12, "YlGnBu", rev = TRUE),
                             reference = "#e8e8e8",
                             bg = "transparent",
                             fg = "black",
                             ...)
 {
+    if (is.null(fill)) fill <- lower.saturation(symbol, 0.4, space = "HCL")
     if (!missing(name))
         classic.theme(name = name, color = color)
     else if (!color)

--- a/R/settings.R
+++ b/R/settings.R
@@ -109,14 +109,14 @@ custom_theme <-
 
 ## (v0.21) Extended to make it easy to provide user-supplied
 ## colors. Defaults to hcl palettes reordered to match classic theme,
-## and region = colorspace::deutan(hcl.colors(12, "YlGnBu"))). Old
+## and region = hcl.colors(12, "YlGnBu")). Old
 ## standard.theme() / canonical.theme() renamed to classic.theme()
 
 standard.theme <- 
 canonical.theme <- function(name, color = TRUE,
-                            symbol = hcl.colors(7, "Dark 3")[c(6, 1, 4, 7, 2, 5, 3)],
-                            fill   = hcl.colors(7, "Pastel 1")[c(6, 1, 4, 7, 2, 5, 3)],
-                            region = c("#0C1F5C", "#172F82", "#304AA2", "#4961B2", "#5F71AF", "#7280B0", "#9FA4B4", "#C2C0B9", "#DBD6C3", "#EFE7CE", "#FDF4D8", "#FFFCDE"),
+                            symbol = palette.colors(8, "Okabe-Ito")[c(6, 2, 4, 8, 7, 3, 5)],
+                            fill   = palette.colors(7, "Set 2")[c(3, 6, 1, 4, 2, 5, 7)],
+                            region = hcl.colors(12, "YlGnBu", rev = TRUE),
                             reference = "#e8e8e8",
                             bg = "transparent",
                             fg = "black",

--- a/R/settings.R
+++ b/R/settings.R
@@ -125,17 +125,17 @@ custom_theme <-
 }
 
 
-## (v0.21) Extended to make it easy to provide user-supplied
-## colors. Defaults to Okabe-Ito reordered to match classic theme somewhat better,
-## and region = hcl.colors(12, "YlGnBu")).
-## Fill colors are by default lightened versions of the symbol colors.
+## (v0.21) Extended to make it easy to provide user-supplied colors.
+## Default symbol colors are from Okabe-Ito, reordered to match classic theme somewhat better.
+## Default fill colors are lightened versions of the symbol colors.
+## Default region colors are the sequential HCL palette "YlGnBu" (approximating the one from ColorBrewer).
 ## Old standard.theme() / canonical.theme() renamed to classic.theme()
 
 standard.theme <- 
 canonical.theme <- function(name, color = TRUE,
-                            symbol = palette.colors(8, "Okabe-Ito")[c(6, 2, 4, 7, 3, 5, 8)],
+                            symbol = palette.colors(palette = "Okabe-Ito")[c(6, 2, 4, 7, 3, 5, 8)],
                             fill   = NULL,
-                            region = hcl.colors(12, "YlGnBu", rev = TRUE),
+                            region = hcl.colors(14, palette = "YlGnBu", rev = TRUE),
                             reference = "gray90",
                             bg = "transparent",
                             fg = "black",

--- a/man/level.colors.Rd
+++ b/man/level.colors.Rd
@@ -60,7 +60,7 @@ level.colors(x, at, col.regions, colors = TRUE, ...)
 depth.col <-
     with(quakes, 
          level.colors(depth, at = do.breaks(range(depth), 30),
-                      col.regions = terrain.colors))
+                      col.regions = hcl.colors))
 
 
 xyplot(lat ~ long | equal.count(stations), quakes,

--- a/man/levelplot.Rd
+++ b/man/levelplot.Rd
@@ -357,7 +357,7 @@ levelplot(z ~ x * y, grid, cuts = 50, scales=list(log="e"), xlab="",
           ylab="", main="Weird Function", sub="with log scales",
           colorkey = FALSE, region = TRUE)
 ## triangular end-points in color key, with a title
-levelplot(z ~ x * y, grid, col.regions = topo.colors(10),
+levelplot(z ~ x * y, grid, col.regions = hcl.colors(10),
           at = c(-Inf, seq(-0.8, 0.8, by = 0.2), Inf))
 
 #S-PLUS example

--- a/man/panel.levelplot.Rd
+++ b/man/panel.levelplot.Rd
@@ -151,7 +151,7 @@ suppressWarnings(plot(levelplot(rnorm(10) ~ 1:10 + sort(runif(10)),
 levelplot(volcano, panel = panel.levelplot.raster)
 
 levelplot(volcano, panel = panel.levelplot.raster,
-          col.regions = topo.colors, cuts = 30, interpolate = TRUE)
+          col.regions = hcl.colors, cuts = 30, interpolate = TRUE)
 
 }
 \author{ Deepayan Sarkar \email{Deepayan.Sarkar@R-project.org}}

--- a/man/panel.pairs.Rd
+++ b/man/panel.pairs.Rd
@@ -174,7 +174,7 @@ diag.panel.splom(x = NULL,
 \examples{
 
 Cmat <- outer(1:6,1:6,
-              function(i,j) rainbow(11, start=.12, end=.5)[i+j-1])
+              function(i,j) hcl.colors(11)[i+j-1]) ## rainbow(11, start=.12, end=.5)[i+j-1])
 
 splom(~diag(6), as.matrix = TRUE,
       panel = function(x, y, i, j, ...) {


### PR DESCRIPTION
Suggestion of new color defaults based on `hcl.colors()` and `palette.colors()` introduced in R 3.6.0 and 4.0.0, respectively:

* Default `symbol` colors are from "Okabe-Ito", reordered to match old theme somewhat better.
* Default `fill` colors are lightened versions of the `symbol` colors.
* Default `region` colors are 14 colors from the sequential HCL palette "YlGnBu" (approximating the one from ColorBrewer). 14 colors work very well when extended to more colors via `colorRampPalette()`.
* Gray colors the were specified by hex codes are now specified by (almost) the same named color, e.g., `gray95` instead of `#f2f2f2`.

In order to obtain lightened colors, the internal `lower.saturation()` function was extended by an argument `space = "RGB"`, defaulting to the old behavior. If `space = "HCL"` is selected instead, the function tries to call `colorspace::lighten()` if available. If `colorspace` is not available it performs the L-only adjustment using `grDevices::convertColor()`. For very light colors this results in colors with a bit too much chroma - but I think this is still preferable to the RGB version which has too little chroma. The `colorspace` version works best, in my opinion, and has an intermediate amount of chroma typically.

The `NAMESPACE` and `DESCRIPTION` were adjusted correspondingly.