### PR TITLE
Fix partial matching issues in tests

### DIFF
--- a/tests/MASSch04.R
+++ b/tests/MASSch04.R
@@ -164,7 +164,7 @@ xyplot(Fertility ~ Education | Cath, data = swiss,
 )
 
 Cath2 <- equal.count(swiss$Catholic, number = 2, overlap = 0)
-Agr <- equal.count(swiss$Agric, number = 3, overlap = 0.25)
+Agr <- equal.count(swiss$Agriculture, number = 3, overlap = 0.25)
 xyplot(Fertility ~ Education | Agr * Cath2, data = swiss,
   span = 1, aspect = "xy",
   panel = function(x, y, span) {

--- a/tests/MASSch04.R
+++ b/tests/MASSch04.R
@@ -112,10 +112,10 @@ bwplot(Age ~ Days | Sex*Lrn*Eth, data = Quine, layout = c(4, 2),
       strip = function(...) strip.default(..., style = 1))
 
 stripplot(Age ~ Days | Sex*Lrn*Eth, data = Quine,
-         jitter = TRUE, layout = c(4, 2))
+         jitter.data = TRUE, layout = c(4, 2))
 
 stripplot(Age ~ Days | Eth*Sex, data = Quine,
-   groups = Lrn, jitter = TRUE,
+   groups = Lrn, jitter.data = TRUE,
    panel = function(x, y, subscripts, jitter.data = F, ...) {
        if(jitter.data)  y <- jitter(as.numeric(y))
        panel.superpose(x, y, subscripts, ...)

--- a/tests/call.R
+++ b/tests/call.R
@@ -40,7 +40,7 @@ test.objects <-
               qqmath.formula = qqmath(~ x + y),
               qqmath.numeric = qqmath(x),
               stripplot.formula = stripplot(g2 ~ x + y, outer = TRUE),
-              stripplot.numeric = stripplot(y, jitter = TRUE),
+              stripplot.numeric = stripplot(y, jitter.data = TRUE),
               qq.formula = qq(g2 ~ x),
               xyplot.formula = xyplot(y ~ x),
               xyplot.ts = xyplot(ts(x)),

--- a/tests/dataframe-methods.R
+++ b/tests/dataframe-methods.R
@@ -7,7 +7,7 @@ mtcars <-
                         labels = c("automatic", "manual")))
 
 stripplot(mtcars, am ~ mpg)
-stripplot(mtcars, gear ~ mpg | am, jitter = TRUE, grid = TRUE)
+stripplot(mtcars, gear ~ mpg | am, jitter.data = TRUE, grid = TRUE)
 bwplot(mtcars, am ~ mpg)
 qq(mtcars, am ~ mpg)
 qqmath(mtcars, ~ mpg | am)

--- a/tests/scales.R
+++ b/tests/scales.R
@@ -19,7 +19,7 @@ dat <-
     data.frame(a = letters[1:10],
                b = c("A","A","A","B","B","A","B","B", "A", "A"))
 
-dat <- dat[sample(1:10, 200, rep = TRUE), ]
+dat <- dat[sample(1:10, 200, replace = TRUE), ]
 dat$y <- rnorm(200, mean = unclass(as.factor(dat$a)))
 
 bwplot(a ~ y | b, data=dat, scales = "same") 

--- a/tests/temp.R
+++ b/tests/temp.R
@@ -26,7 +26,7 @@ xyplot(y ~ x | g, subset = g != "2")
 xyplot(y ~ x | g, subset = g != "2",
        panel = function(x, y, subscripts) {
            print(subscripts)
-           ltext(x, y, lab = subscripts)
+           ltext(x, y, labels = subscripts)
        })
 
 
@@ -40,14 +40,14 @@ subset <- 20:40
 xyplot(y ~ x,
        panel = function(x, y, subscripts) {
            print(subscripts)
-           ltext(x, y, lab = subscripts)
+           ltext(x, y, labels = subscripts)
        })
 
 ## gives subscripts = 20:40
 xyplot(y ~ x, subset = subset,
        panel = function(x, y, subscripts) {
            print(subscripts)
-           ltext(x, y, lab = subscripts)
+           ltext(x, y, labels = subscripts)
        })
 
 g <- gl(2,1,50)

--- a/tests/test.R
+++ b/tests/test.R
@@ -88,8 +88,8 @@ splom(iris2, groups = iris$Species,
       pscales = list(list(at = 6, lab = "six"), list(at = 3), list(at = 4), list(at = 1)))
 
 splom(iris2, groups = iris$Species,
-      pscales = list(list(at = 6, lab = "six", limits = c(-10, 10)),
-      list(at = 3), list(at = 4), list(limits = c(-5, 5))))
+      pscales = list(list(at = 6, lab = "six", lim = c(-10, 10)),
+      list(at = 3), list(at = 4), list(lim = c(-5, 5))))
 
 
 ## factors in formula
@@ -116,9 +116,9 @@ splom(~iris[1:3]|Species, data = iris,
       layout=c(2,2), pscales = 0,
       varnames = c("Sepal\nLength", "Sepal\nWidth", "Petal\nLength"),
       page = function(...) {
-          ltext(x = seq(.6, .8, len = 4), 
-                y = seq(.9, .6, len = 4), 
-                lab = c("Three", "Varieties", "of", "Iris"),
+          ltext(x = seq(.6, .8, length.out = 4), 
+                y = seq(.9, .6, length.out = 4), 
+                labels = c("Three", "Varieties", "of", "Iris"),
                 cex = 2)
       }, par.settings = list(clip = list(panel = FALSE)))
 

--- a/tests/test.R
+++ b/tests/test.R
@@ -13,7 +13,7 @@ densityplot(~ 1:5 | letters[1:5])
 x <- rnorm(200)
 y <- rnorm(200)
 z <- equal.count(rnorm(200))
-a <- factor(rep(1:3, len = 200))
+a <- factor(rep_len(1:3, 200))
 
 df.test <- list(xx = x+1-min(x), yy = y, zz = z, aa = a)
 


### PR DESCRIPTION
One complication is the changes to R/splom.R. Basically we have a contradiction between the package source and what's tested:

https://github.com/deepayan/lattice/blob/f216545a541cc346ba429938afa9f5ae6cdf3bb4/tests/test.R#L91

In effect, under partial matching, any `pscales` entry with a name starting with `lim` is accepted, but any user with strict matching rules must supply `lim`.

If the intention truly is to let the user supply any `^lim.*` list item, that should be better encoded in the sources (and perhaps documented); this PR assumes the test is in error instead to avoid back-compatibility issues.

<details>

To reproduce:

```r
setwd('tests')
pmatchRe = "partial( argument)? match"
writeLines(con=".Rprofile", c(
  "options(warnPartialMatchArgs=TRUE, warnPartialMatchAttr=TRUE, warnPartialMatchDollar=TRUE)",
  sprintf("globalCallingHandlers(warning=function(c) if (grepl('%s', conditionMessage(c))) stop(c) else warning(c))", pmatchRe)
))

tests = list.files(pattern='[.][rR]$', full.names=TRUE)
for (t in tests) local({
  system2("R", c("CMD", "BATCH", t))
  tmp = paste0(basename(t), "out")
  on.exit(unlink(tmp))
  l = grep(pmatchRe, readLines(tmp), value=TRUE)
  if (length(l)) message(t, "\n", l)
})

unlink(".Rprofile")
```

</details>