### PR TITLE
panel.levelplot.raster: fix for y being a factor

### DIFF
--- a/R/levelplot.R
+++ b/R/levelplot.R
@@ -983,7 +983,7 @@ panel.levelplot.raster <-
     ## same things for y
     if (y.is.factor)
     {
-        ux <- seq(from = min(y, na.rm = TRUE), to = max(y, na.rm = TRUE))
+        uy <- seq(from = min(y, na.rm = TRUE), to = max(y, na.rm = TRUE))
         ywid <- 1L
     }
     else


### PR DESCRIPTION
Steps to reproduce:

```r
library(lattice)

x <- expand.grid(factor = factor(letters[1:3]), numeric = 1:4)
x$value <- runif(nrow(x))

levelplot(value ~ factor + numeric, x, useRaster = TRUE) # works well
levelplot(value ~ numeric + factor, x, useRaster = TRUE) # fails
```

The code fails due to a typo: the `y.is.factor` branch creates a variable named `ux` but later the code expects to work with `uy`.